### PR TITLE
Make DHCP failover ports configurable (Fixes #7)

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,12 @@ isc_dhcp_failover_info:
   failover_group: dhcp-nodes
   # Define the node in which should be considered the primary
   primary: "{{ groups['dhcp-nodes'][0] }}"
+  # Define the port to be used on primary node
+  primary_port: "519"
   # Define the node in which should be considered the secondary
   secondary: "{{ groups['dhcp-nodes'][1] }}"
+  # Define the port to be used on secondary node
+  secondary_port: "520"
 ```
 
 ## Role Variables

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -52,8 +52,12 @@ isc_dhcp_failover_info: []
   # failover_group: dhcp-nodes
   # # Define the node in which should be considered the primary
   # primary: "{{ groups['dhcp-nodes'][0] }}"
+  # # Define the port to be used on primary node
+  # primary_port: "519"
   # # Define the node in which should be considered the secondary
   # secondary: "{{ groups['dhcp-nodes'][1] }}"
+  # # Define the port to be used on secondary node
+  # secondary_port: "520"
 
 # On what interfaces should the DHCP server (dhcpd) serve DHCP requests?
 isc_dhcp_listen_interfaces: []

--- a/templates/etc/dhcp/dhcpd.conf.j2
+++ b/templates/etc/dhcp/dhcpd.conf.j2
@@ -51,7 +51,7 @@ failover peer "failover" {
   peer address {{ host }};
 {%       endif %}
 {%     endfor %}
-  peer port {{ isc_dhcp_failover_info.secondary_port|default('519') }};
+  peer port {{ isc_dhcp_failover_info.primary_port|default('519') }};
   load balance max seconds 3;
 }
 {%   endif %}

--- a/templates/etc/dhcp/dhcpd.conf.j2
+++ b/templates/etc/dhcp/dhcpd.conf.j2
@@ -28,13 +28,13 @@ log-facility local7;
 failover peer "failover" {
   primary;
   address {{ isc_dhcp_failover_info.failover_address }};
-  port {{ isc_dhcp_failover_infog.primary_port|default('519') }};
+  port {{ isc_dhcp_failover_info.primary_port|default('519') }};
 {%     for host in groups[isc_dhcp_failover_info.failover_group] %}
 {%       if inventory_hostname != host %}
   peer address {{ host }};
 {%       endif %}
 {%     endfor %}
-  peer port {{ isc_dhcp_failover_infog.secondary_port|default('520') }};
+  peer port {{ isc_dhcp_failover_info.secondary_port|default('520') }};
   mclt 3600;
   split 128;
   load balance max seconds 3;
@@ -45,13 +45,13 @@ failover peer "failover" {
 failover peer "failover" {
   secondary;
   address {{ isc_dhcp_failover_info.failover_address }};
-  port {{ isc_dhcp_failover_infog.secondary_port|default('520') }};
+  port {{ isc_dhcp_failover_info.secondary_port|default('520') }};
 {%     for host in groups[isc_dhcp_failover_info.failover_group] %}
 {%       if inventory_hostname != host %}
   peer address {{ host }};
 {%       endif %}
 {%     endfor %}
-  peer port {{ isc_dhcp_failover_infog.secondary_port|default('519') }};
+  peer port {{ isc_dhcp_failover_info.secondary_port|default('519') }};
   load balance max seconds 3;
 }
 {%   endif %}

--- a/templates/etc/dhcp/dhcpd.conf.j2
+++ b/templates/etc/dhcp/dhcpd.conf.j2
@@ -28,13 +28,13 @@ log-facility local7;
 failover peer "failover" {
   primary;
   address {{ isc_dhcp_failover_info.failover_address }};
-  port 519;
+  port {{ isc_dhcp_failover_infog.primary_port|default('519') }};
 {%     for host in groups[isc_dhcp_failover_info.failover_group] %}
 {%       if inventory_hostname != host %}
   peer address {{ host }};
 {%       endif %}
 {%     endfor %}
-  peer port 520;
+  peer port {{ isc_dhcp_failover_infog.secondary_port|default('520') }};
   mclt 3600;
   split 128;
   load balance max seconds 3;
@@ -45,13 +45,13 @@ failover peer "failover" {
 failover peer "failover" {
   secondary;
   address {{ isc_dhcp_failover_info.failover_address }};
-  port 520;
+  port {{ isc_dhcp_failover_infog.secondary_port|default('520') }};
 {%     for host in groups[isc_dhcp_failover_info.failover_group] %}
 {%       if inventory_hostname != host %}
   peer address {{ host }};
 {%       endif %}
 {%     endfor %}
-  peer port 519;
+  peer port {{ isc_dhcp_failover_infog.secondary_port|default('519') }};
   load balance max seconds 3;
 }
 {%   endif %}


### PR DESCRIPTION
* On CentOS 7, the configured failover ports (519 and 520) are blocked
  by SELinux. The IANA assigned ports (647, 847) are not blocked, though.
* If you set the ports to (647, 847), it works out of the box even with
  SELinux enabled.